### PR TITLE
fix: intersphinx mapping for Python docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -72,7 +72,7 @@ extensions = [
 
 # Intersphinx mapping
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/dev", None),
+    "python": ("https://docs.python.org/3", None),
     # kept here as an example
     # "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
     # "numpy": ("https://numpy.org/devdocs", None),

--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/doc/source/conf.py
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/doc/source/conf.py
@@ -68,7 +68,7 @@ extensions = [
 
 # Intersphinx mapping
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/dev", None),
+    "python": ("https://docs.python.org/3", None),
     # kept here as an example
     # "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
     # "numpy": ("https://numpy.org/devdocs", None),

--- a/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/doc/source/conf.py
+++ b/src/ansys/templates/python/osl_solution/{{cookiecutter.__project_name_slug}}/doc/source/conf.py
@@ -56,7 +56,7 @@ extensions = [
 ]
 
 # Intersphinx mapping
-intersphinx_mapping = {"python": ("https://docs.python.org/dev", None)}
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 # numpydoc configuration
 numpydoc_show_class_members = False

--- a/src/ansys/templates/python/solution/{{cookiecutter.__project_name_slug}}/doc/source/conf.py
+++ b/src/ansys/templates/python/solution/{{cookiecutter.__project_name_slug}}/doc/source/conf.py
@@ -56,7 +56,7 @@ extensions = [
 ]
 
 # Intersphinx mapping
-intersphinx_mapping = {"python": ("https://docs.python.org/dev", None)}
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 # numpydoc configuration
 numpydoc_show_class_members = False


### PR DESCRIPTION
As title says. We should point towards the latest stable version of the Python docs